### PR TITLE
Requirements separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # bids_neuropoly
 Python package that deals with BIDS structure for filtering data (specific to NeuroPoly developments)
 
-## Installation
+## API Installation
 ~~~
 git clone https://github.com/neuropoly/bids_neuropoly.git
 cd bids_neuropoly
 pip install -e .
+~~~
+
+## Convert dcm2nii script installation
+~~~
+git clone https://github.com/neuropoly/bids_neuropoly.git
+cd bids_neuropoly
+pip install -r scripts/requirements.txt
 ~~~
 
 ## Convert Dicom to BIDS-compatible Nifti dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 pybids>=0.6.5
 nibabel>=2.3.0
 pandas>=0.23.0
-gitpython
-logging
-subprocess

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+gitpython
+logging


### PR DESCRIPTION
The aim of this PR is to split the API & script (convert_dcm2nii) requirements.

To install the  **convert_dcm2nii** script run:  `pip install -r scripts/requirements.txt`

Fixes #7 