### PR TITLE
Ignore files in .git folder

### DIFF
--- a/bids_neuropoly/bids.py
+++ b/bids_neuropoly/bids.py
@@ -130,6 +130,9 @@ class BIDS(object):
         for i in self.root_path.rglob('*.*'):
             if i.name.lower() in self.METADATA_FNAMES:
                 continue
+            if ".git" in str(i.absolute()):
+                continue
+
 
             # Check if its a nifti file
             if self.NIFTI_EXTENSION in i.suffixes:


### PR DESCRIPTION
As discussed with @charleygros .nii.gz files in the .git folder are creating issues in ivadomed